### PR TITLE
 Add poweron architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: go
-
+arch:
+  - ppc64le
+  - amd64
 go:
   - 1.14.x
   - 1.x


### PR DESCRIPTION
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing, For more info please tag @gerrith3.
