### PR TITLE
fix: wrong type crash of count in Domain.List

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -3,6 +3,7 @@ package goinwx
 import (
 	"errors"
 	"time"
+	"strconv"
 
 	"github.com/fatih/structs"
 	"github.com/mitchellh/mapstructure"
@@ -140,6 +141,19 @@ func (s *DomainService) List(request *DomainListRequest) (*DomainList, error) {
 	resp, err := s.client.Do(req)
 	if err != nil {
 		return nil, err
+	}
+
+	// This is a (temporary) workaround to convert the API response from string to int.
+	// The code only applies when string is being return, otherwise it's being skipped.
+	// As per docs at https://www.inwx.com/en/help/apidoc/f/ch02s08.html#domain.list we
+	// should get int here, but apparently it's not the case.
+	// Ticket 10026265 with INWX was raised.
+	if countStr, ok := (*resp)["count"].(string); ok {
+		// If we land here, we got string back but we expect int.
+		// Converting value to int and writing it to the response.
+		if num, ok := strconv.Atoi(countStr); ok == nil {
+			(*resp)["count"] = num
+		}
 	}
 
 	var result DomainList

--- a/domain.go
+++ b/domain.go
@@ -2,8 +2,8 @@ package goinwx
 
 import (
 	"errors"
-	"time"
 	"strconv"
+	"time"
 
 	"github.com/fatih/structs"
 	"github.com/mitchellh/mapstructure"
@@ -145,14 +145,13 @@ func (s *DomainService) List(request *DomainListRequest) (*DomainList, error) {
 
 	// This is a (temporary) workaround to convert the API response from string to int.
 	// The code only applies when string is being return, otherwise it's being skipped.
-	// As per docs at https://www.inwx.com/en/help/apidoc/f/ch02s08.html#domain.list we
-	// should get int here, but apparently it's not the case.
+	// As per docs at https://www.inwx.com/en/help/apidoc/f/ch02s08.html#domain.list we should get int here, but apparently it's not the case.
 	// Ticket 10026265 with INWX was raised.
-	if countStr, ok := (*resp)["count"].(string); ok {
-		// If we land here, we got string back but we expect int.
+	if countStr, ok := resp["count"].(string); ok {
+		// If we land here, we got string back, but we expect int.
 		// Converting value to int and writing it to the response.
 		if num, ok := strconv.Atoi(countStr); ok == nil {
-			(*resp)["count"] = num
+			resp["count"] = num
 		}
 	}
 


### PR DESCRIPTION
When using dnscontrol there's currently an issue - see [issue](https://github.com/StackExchange/dnscontrol/issues/1091#issuecomment-1328319309) for more context. Upon further research it looks like INWX is not coherent with their own documentation: They return `count` as string, while their [documentation](https://www.inwx.com/en/help/apidoc/f/ch02s08.html#domain.list) indicates it is supposed to be integer.

I've reached out to their support in ticket 10026265 about 2 months now - and there weren't able to neither fix the API-perspective nor adjust the API accordingly. So I'll propose this workaround as a temporary fix. It works now, and should when they (if ever) fix their backend.

Double-checking the type in the `List()` function proofs the same: The API call returns `count` as `string`, where it should be `int`. The added code checks if it is string, if so it converts it to int and overwrites the value.

dnsccontrol fails with:
```
WARNING: Error creating domain: 1 error(s) decoding:

* 'Count' expected type 'int', got unconvertible type 'string', value: '16'
Done. 0 corrections.
```