### PR TITLE
feat: add urlAppend to NameserverRecordRequest

### DIFF
--- a/nameserver.go
+++ b/nameserver.go
@@ -197,6 +197,7 @@ type NameserverRecordRequest struct {
 	Name                   string `structs:"name,omitempty"`
 	TTL                    int    `structs:"ttl,omitempty"`
 	Priority               int    `structs:"prio,omitempty"`
+	URLAppend              bool   `structs:"urlAppend,omitempty"`
 	URLRedirectType        string `structs:"urlRedirectType,omitempty"`
 	URLRedirectTitle       string `structs:"urlRedirectTitle,omitempty"`
 	URLRedirectDescription string `structs:"urlRedirectDescription,omitempty"`


### PR DESCRIPTION
Hello,

URL records have another optional boolean field, called `urlAppend`. This PR adds support for toggling this.

See https://www.inwx.com/en/help/apidoc/f/ch02s15.html#nameserver.createRecord for upstream API's documentation.

Thanks!