### PR TITLE
feat: add nameserver.ListWithParams

### DIFF
--- a/nameserver.go
+++ b/nameserver.go
@@ -64,7 +64,35 @@ func (s *NameserverService) Info(request *NameserverInfoRequest) (*NameserverInf
 }
 
 // List lists nameservers for a domain.
-func (s *NameserverService) List(request *NameserverListRequest) (*NameserverListResponse, error) {
+// Deprecated: use ListWithParams instead.
+func (s *NameserverService) List(domain string) (*NameserverListResponse, error) {
+	requestMap := map[string]interface{}{
+		"domain": "*",
+		"wide":   2,
+	}
+
+	if domain != "" {
+		requestMap["domain"] = domain
+	}
+
+	req := s.client.NewRequest(methodNameserverList, requestMap)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	result := NameserverListResponse{}
+	err = mapstructure.Decode(resp, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// ListWithParams lists nameservers for a domain.
+func (s *NameserverService) ListWithParams(request *NameserverListRequest) (*NameserverListResponse, error) {
 	if request == nil {
 		return nil, errors.New("request can't be nil")
 	}
@@ -159,7 +187,7 @@ func (s *NameserverService) DeleteRecord(recID int) error {
 
 // FindRecordByID search a DNS record by ID.
 func (s *NameserverService) FindRecordByID(recID int) (*NameserverRecord, *NameserverDomain, error) {
-	listResp, err := s.client.Nameservers.List(&NameserverListRequest{})
+	listResp, err := s.client.Nameservers.ListWithParams(&NameserverListRequest{})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -232,6 +260,10 @@ type NameserverInfoRequest struct {
 	Priority int    `structs:"prio,omitempty"`
 }
 
+// NamserverInfoResponse API model.
+// Deprecated: Use NameserverInfoResponse instead.
+type NamserverInfoResponse = NameserverInfoResponse
+
 // NameserverInfoResponse API model.
 type NameserverInfoResponse struct {
 	RoID          int                `mapstructure:"roId"`
@@ -273,6 +305,10 @@ type NameserverListRequest struct {
 	Page      int    `structs:"page,omitempty"`
 	PageLimit int    `structs:"pagelimit,omitempty"`
 }
+
+// NamserverListResponse API model.
+// Deprecated: Use NameserverListResponse instead.
+type NamserverListResponse = NameserverListResponse
 
 // NameserverListResponse API model.
 type NameserverListResponse struct {

--- a/nameserver.go
+++ b/nameserver.go
@@ -64,15 +64,13 @@ func (s *NameserverService) Info(request *NameserverInfoRequest) (*NameserverInf
 }
 
 // List lists nameservers for a domain.
-func (s *NameserverService) List(domain string) (*NameserverListResponse, error) {
-	requestMap := map[string]interface{}{
-		"domain": "*",
-		"wide":   2,
+func (s *NameserverService) List(request *NameserverListRequest) (*NameserverListResponse, error) {
+	if request == nil {
+		return nil, errors.New("request can't be nil")
 	}
 
-	if domain != "" {
-		requestMap["domain"] = domain
-	}
+	requestMap := structs.Map(request)
+	requestMap["wide"] = "2"
 
 	req := s.client.NewRequest(methodNameserverList, requestMap)
 
@@ -161,7 +159,7 @@ func (s *NameserverService) DeleteRecord(recID int) error {
 
 // FindRecordByID search a DNS record by ID.
 func (s *NameserverService) FindRecordByID(recID int) (*NameserverRecord, *NameserverDomain, error) {
-	listResp, err := s.client.Nameservers.List("")
+	listResp, err := s.client.Nameservers.List(&NameserverListRequest{})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -266,6 +264,14 @@ type NameserverRecord struct {
 	URLRedirectDescription string `mapstructure:"urlRedirectDescription"`
 	URLRedirectKeywords    string `mapstructure:"urlRedirectKeywords"`
 	URLRedirectFavIcon     string `mapstructure:"urlRedirectFavIcon"`
+}
+
+// NameserverListRequest API model.
+type NameserverListRequest struct {
+	Domain    string `structs:"domain,omitempty"`
+	Wide      int    `structs:"wide,omitempty"`
+	Page      int    `structs:"page,omitempty"`
+	PageLimit int    `structs:"pagelimit,omitempty"`
 }
 
 // NameserverListResponse API model.

--- a/nameserver.go
+++ b/nameserver.go
@@ -46,7 +46,7 @@ func (s *NameserverService) Check(domain string, nameservers []string) (*Nameser
 }
 
 // Info gets information.
-func (s *NameserverService) Info(request *NameserverInfoRequest) (*NamserverInfoResponse, error) {
+func (s *NameserverService) Info(request *NameserverInfoRequest) (*NameserverInfoResponse, error) {
 	req := s.client.NewRequest(methodNameserverInfo, structs.Map(request))
 
 	resp, err := s.client.Do(req)
@@ -54,7 +54,7 @@ func (s *NameserverService) Info(request *NameserverInfoRequest) (*NamserverInfo
 		return nil, err
 	}
 
-	result := NamserverInfoResponse{}
+	result := NameserverInfoResponse{}
 	err = mapstructure.Decode(resp, &result)
 	if err != nil {
 		return nil, err
@@ -64,7 +64,7 @@ func (s *NameserverService) Info(request *NameserverInfoRequest) (*NamserverInfo
 }
 
 // List lists nameservers for a domain.
-func (s *NameserverService) List(domain string) (*NamserverListResponse, error) {
+func (s *NameserverService) List(domain string) (*NameserverListResponse, error) {
 	requestMap := map[string]interface{}{
 		"domain": "*",
 		"wide":   2,
@@ -81,7 +81,7 @@ func (s *NameserverService) List(domain string) (*NamserverListResponse, error) 
 		return nil, err
 	}
 
-	result := NamserverListResponse{}
+	result := NameserverListResponse{}
 	err = mapstructure.Decode(resp, &result)
 	if err != nil {
 		return nil, err
@@ -234,8 +234,8 @@ type NameserverInfoRequest struct {
 	Priority int    `structs:"prio,omitempty"`
 }
 
-// NamserverInfoResponse API model.
-type NamserverInfoResponse struct {
+// NameserverInfoResponse API model.
+type NameserverInfoResponse struct {
 	RoID          int                `mapstructure:"roId"`
 	Domain        string             `mapstructure:"domain"`
 	Type          string             `mapstructure:"type"`
@@ -268,8 +268,8 @@ type NameserverRecord struct {
 	URLRedirectFavIcon     string `mapstructure:"urlRedirectFavIcon"`
 }
 
-// NamserverListResponse API model.
-type NamserverListResponse struct {
+// NameserverListResponse API model.
+type NameserverListResponse struct {
 	Count   int                `mapstructure:"count"`
 	Domains []NameserverDomain `mapstructure:"domains"`
 }


### PR DESCRIPTION
Hello,

While trying to use nameserver/List in StackExchange/dnscontrol#2577, we discovered that nameserver.go/List is not following the struct-as-request paradigm that allows for setting all input fields, as most other methods do.

This PR:
* introduces a new `NameserverListRequest`, mirroring the List input fields in [inwx API](https://www.inwx.com/en/help/apidoc/f/ch02s15.html#nameserver.list)
~~* Changes List() to use NameserverListRequest for input fields.~~
~~* Fixes a few mostly-internal typos (Namserver* -> Nameserver*)~~

Thanks!
