### PR TITLE
feat: add URLAppend to NameserverRecord

### DIFF
--- a/nameserver.go
+++ b/nameserver.go
@@ -291,6 +291,7 @@ type NameserverRecord struct {
 	Content                string `mapstructure:"content"`
 	TTL                    int    `mapstructure:"TTL"`
 	Priority               int    `mapstructure:"prio"`
+	URLAppend              bool   `mapstructure:"urlAppend,omitempty"`
 	URLRedirectType        string `mapstructure:"urlRedirectType"`
 	URLRedirectTitle       string `mapstructure:"urlRedirectTitle"`
 	URLRedirectDescription string `mapstructure:"urlRedirectDescription"`


### PR DESCRIPTION
Hello,

URL records have another optional boolean field, called urlAppend. This PR adds support for the one that was missed in #8, in `NameserverRecord`.

See https://www.inwx.com/en/help/apidoc/f/ch02s15.html#nameserver.createRecord for upstream API's documentation.

Thanks!

